### PR TITLE
Manage dependencies properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 *.DS_Store
+# Go folders
+vendor/
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a
 *.so
 moscar
+gomoscar
 # Folders
 _obj
 _test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # gomoscar
 Moscargo v2
+
+# Build
+`git clone git@github.com:arubdesu/gomoscar.git $GOPATH/src/github.com/arubdesu/gomoscar`
+`cd $GOPATH/src/github.com/arubdesu/gomoscar`
+`glide install`
+`go build -i` or `go install`
+
+## Installing and updating dependencies
+
+Moscargo v2 uses [Glide](https://github.com/Masterminds/glide#install) to manage external dependencies
+
+To install the latest version of required packages, use the `glide install` command, 
+which will inspect the `glide.lock` file and download the correct versions into the `/vendor` folder.

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,12 @@
+hash: 6e6c75ac037e101088f94452802041f618434008069bbd13cf60af91d7773d71
+updated: 2016-09-18T13:55:31.267293408-04:00
+imports:
+- name: github.com/groob/plist
+  version: e9ca5cd129407b401d850bc3248338865a7490ae
+- name: github.com/micromdm/squirrel
+  version: 3f7f6185b0dc799cbd9f1ea81352c0b7b3227419
+  subpackages:
+  - munki/datastore
+  - munki/models
+  - munki/munki
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,6 @@
+package: github.com/arubdesu/gomoscar
+import:
+- package: github.com/micromdm/squirrel
+  subpackages:
+  - munki/datastore
+  - munki/models

--- a/moscar.go
+++ b/moscar.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/micromdm/squirrel/munki/datastore"
-	"github.com/micromdm/squirrel/munki/models"
 	"html/template"
 	"io"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/micromdm/squirrel/munki/datastore"
+	"github.com/micromdm/squirrel/munki/munki"
 )
 
 const STATIC_URL string = "/static/"
@@ -29,7 +30,7 @@ type ParsedPkginfo struct {
 	DownloadURL string
 }
 
-func Parse(in_pkginfo *models.PkgsInfo, ppi *ParsedPkginfo) *ParsedPkginfo {
+func Parse(in_pkginfo *munki.PkgsInfo, ppi *ParsedPkginfo) *ParsedPkginfo {
 	ppi.Icon = in_pkginfo.IconName
 	ppi.Name = in_pkginfo.Name
 	ppi.Descript = in_pkginfo.Description


### PR DESCRIPTION
This PR does a few things to ensure that the project still compiles even if upstream libraries 
change:
- update dependencies to their latest version
- add a glide file for tracking upstream dependencies
- add info to readme about downloading and installing the project

I noticed that the project was relying on an older version of squirrel, which had changed it's directory structure, and that was causing `gomoscar` to no longer compile. 
